### PR TITLE
Removes departmental budget cards from Department Head Locker item pools.

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
@@ -6,7 +6,7 @@
 /obj/structure/closet/secure_closet/quartermaster/PopulateContents()
 	..()
 	new /obj/item/stack/tape(src) //WS Edit - Tape
-	new /obj/item/card/id/departmental_budget/car(src)//WS Edit - Budget Cards
+	// new /obj/item/card/id/departmental_budget/car(src)//WS Edit - Budget Cards [NOT BALANCED FOR SHIPTEST]
 	new /obj/item/clothing/neck/cloak/qm(src)
 	new /obj/item/storage/lockbox/medal/cargo(src)
 	new /obj/item/clothing/under/rank/cargo/qm(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -85,7 +85,7 @@
 	new /obj/item/clothing/head/beret/cmo(src) //Berets
 	new /obj/item/clothing/under/rank/command(src) //Better command uniforms
 	new /obj/item/storage/box/hypospray/CMO(src) //Hypo mk. 2s
-	new /obj/item/card/id/departmental_budget/med(src) //Budget cards
+	//new /obj/item/card/id/departmental_budget/med(src) //Budget cards [NOT BALANCED FOR SHIPTEST]
 	//WS End
 	new /obj/item/clothing/neck/cloak/cmo(src)
 	new /obj/item/clothing/suit/bio_suit/cmo(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
@@ -6,7 +6,7 @@
 /obj/structure/closet/secure_closet/RD/PopulateContents()
 	..()
 	new /obj/item/clothing/head/beret/rd(src) //WS edit - Berets
-	new /obj/item/card/id/departmental_budget/sci(src) //WS Edit - Budget Cards
+	// new /obj/item/card/id/departmental_budget/sci(src) //WS Edit - Budget Cards [NOT BALANCED FOR SHIPTEST]
 	new /obj/item/clothing/under/rank/command(src) //WS edit - better command uniforms
 	new /obj/item/clothing/neck/cloak/rd(src)
 	new /obj/item/clothing/suit/bio_suit/scientist(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -7,7 +7,7 @@
 	..()
 	//WS Begin
 	new /obj/item/clothing/head/beret/captain(src) //Berets
-	new /obj/item/card/id/departmental_budget/civ(src) //Budget Cards
+	// new /obj/item/card/id/departmental_budget/civ(src) //Budget Cards [NOT BALANCED FOR SHIPTEST]
 	new /obj/item/storage/backpack/messenger/com(src) //Messenger Bags
 	//WS End
 	new /obj/item/clothing/suit/hooded/wintercoat/captain(src)
@@ -48,7 +48,7 @@
 
 /obj/structure/closet/secure_closet/head_of_personnel/PopulateContents()
 	..()
-	new /obj/item/card/id/departmental_budget/srv(src) //WS Edit - Budget Cards
+	// new /obj/item/card/id/departmental_budget/srv(src) //WS Edit - Budget Cards [NOT BALANCED FOR SHIPTEST]
 	new /obj/item/clothing/neck/cloak/head_of_personnel(src)
 	new /obj/item/storage/lockbox/medal/service(src)
 	new /obj/item/clothing/head/beret/hop(src) //WS edit - More Berets
@@ -80,7 +80,7 @@
 
 /obj/structure/closet/secure_closet/hos/PopulateContents()
 	..()
-	new /obj/item/card/id/departmental_budget/sec(src) //WS edit - budget card
+	// new /obj/item/card/id/departmental_budget/sec(src) //WS edit - budget card [NOT BALANCED FOR SHIPTEST]
 	new /obj/item/storage/box/deputy(src) //WS edit - Small QoL Brig additions
 	new /obj/item/clothing/neck/cloak/hos(src)
 	new /obj/item/clothing/under/rank/command(src) //WS edit - better command uniforms


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes departmental cards from department head locker pools.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
upwards of 80k credits being accesable to crews aint good, especially if they can make cargo.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: removes deparmental cards from the head locker item pools.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
